### PR TITLE
Feature: Automatic SSL Virtual Host Detection and Service API Call Protocol Switch

### DIFF
--- a/autoloads/recaptchatemplateoperator.php
+++ b/autoloads/recaptchatemplateoperator.php
@@ -70,11 +70,24 @@ class reCAPTCHATemplateOperator {
         $currentUser = eZUser::currentUser();
         $accessAllowed = $currentUser->hasAccessTo( 'recaptcha', 'bypass_captcha' );
         if ($accessAllowed["accessWord"] == 'yes')
+        {
           $operatorValue = 'User bypasses CAPTCHA';
+        }
         else
+        {
           // Run the HTML generation code from the reCAPTCHA PHP library 
-  				$operatorValue = recaptcha_get_html($key);
-				break;
+             if( $_SERVER['SERVER_PORT'] == 443 )
+             {
+                 $operatorValue = recaptcha_get_html( $key, '', true );
+             }
+             else
+             {
+                 $operatorValue = recaptcha_get_html( $key, '', false );
+             }
+         }
+
+         break;
+
 		}
 	}
 };


### PR DESCRIPTION
Hello,

This pull request provides for default ssl support for use automatically in calling via ssl on ssl only hosts. This ensures that current web browsers do not block the request because of it's protocol usage.

We chose to detect the ssl host via standard port instead of using a ini setting as this leaves the developer free of managing yet another ini setting between web hosts the extension is deployed to.

These changes were needed for a recent client project which used an ssl only host in production.

We hope these changes are understood and acceptable to you for merge so that the community will once again have a working out of the box recaptcha solution for ezpublish legacy going forward.

Thanks again for your continued support.

Cheers,
Brookins Consulting 